### PR TITLE
Working example

### DIFF
--- a/remote_test/cat.py
+++ b/remote_test/cat.py
@@ -36,6 +36,7 @@ class InnerCatalog(Catalog):
                 driver='remote_test.cat.MyDriver',
                 description='',
                 catalog=self,
+                direct_access='forbid',
                 args={'shape': self._shape, 'color': color})
 
     def read_partition(self, partition):
@@ -51,6 +52,7 @@ class OuterCatalog(Catalog):
                 driver='remote_test.cat.InnerCatalog',
                 description='',
                 catalog=self,
+                direct_access='forbid',
                 args={'shape': shape})
 
     def read_partition(self, partition):

--- a/remote_test/cat.py
+++ b/remote_test/cat.py
@@ -1,7 +1,9 @@
 from intake.catalog.local import Catalog, DataSource, LocalCatalogEntry
+from intake.source.base import Schema
 from intake.container import container_map
 
 class MyDriver(DataSource):
+    container = 'python'
 
     def __init__(self, shape, color, **kwargs):
         self._shape = args['shape']
@@ -12,6 +14,12 @@ class MyDriver(DataSource):
         print('fetching data for {(self._shape, self_color)}')
         print("PARTITION", partition)
         return self._shape, self._color
+
+    def _get_schema(self):
+        return Schema(
+            datashape=(2,),
+            npartitions=1,
+            extra_metadata={})
 
 
 class InnerCatalog(Catalog):

--- a/remote_test/cat.py
+++ b/remote_test/cat.py
@@ -6,12 +6,12 @@ class MyDriver(DataSource):
     container = 'python'
 
     def __init__(self, shape, color, **kwargs):
-        self._shape = args['shape']
-        self._color = args['color']
+        self._shape = shape
+        self._color = color
         super().__init__(**kwargs)
 
     def _get_partition(self, partition):
-        print('fetching data for {(self._shape, self_color)}')
+        print(f'fetching data for {(self._shape, self._color)}')
         print("PARTITION", partition)
         return self._shape, self._color
 
@@ -26,7 +26,7 @@ class InnerCatalog(Catalog):
 
     def __init__(self, shape, **kwargs):
         self._shape = shape
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
 
     def _load(self):
         print(f'loaded inner catalog for {self._shape}')

--- a/remote_test/test_remote.py
+++ b/remote_test/test_remote.py
@@ -36,4 +36,8 @@ def test_remote(intake_server):
     cat_remote = intake.open_catalog(intake_server)
     assert 'outer' in cat_remote
     assert 'outer' in cat_local
-    print(tuple(cat_remote['outer']()['circle']))
+    print(tuple(cat_remote))
+    print(tuple(cat_remote['outer']()))
+    print(tuple(cat_remote['outer']()['circle']()))
+    print(cat_remote['outer']()['circle']()['green'])
+    print(cat_remote['outer']()['circle']()['green'].read())


### PR DESCRIPTION
These changes get `pytest` passing. See commit messages for details.

Debugging this was challenging. I think intake should fail earlier if it is
missing crucial attributes and provide more helpful error messages.